### PR TITLE
Add support for reading options from a configuration file and CLI params

### DIFF
--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -23,8 +23,8 @@ cert =
 key =
 
 [customize]
-# Display messages to console (default: 1).
-verbose = 1
+# Display messages to console (default: 0).
+verbose = 0
 # Interval, in seconds, after which we will check for new events (default: 5).
 event_check_interval = 5
 # Interval, in seconds, to reload known monitors (default: 300).

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -17,8 +17,8 @@ api_key =
 token_file = /var/lib/zmeventnotification/tokens
 
 [ssl]
-# Enable SSL (default: 0).
-enable = 0
+# Enable SSL (default: 1).
+enable = 1
 # Location to SSL cert (no default).
 cert =
 # Location to SSL key (no default).

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -1,10 +1,6 @@
 [network]
 # Port for Websockets connection (default: 9000).
 port = 9000
-# Interval, in seconds, after which we will check for new events (default: 5).
-event_check_interval = 5
-# Interval, in seconds, to reload known monitors (default: 300).
-monitor_reload_interval = 300
 
 [auth]
 # Check username/password against ZoneMinder database (default: 1).
@@ -29,6 +25,10 @@ key =
 [customize]
 # Display messages to console (default: 1).
 log_to_console = 1
+# Interval, in seconds, after which we will check for new events (default: 5).
+event_check_interval = 5
+# Interval, in seconds, to reload known monitors (default: 300).
+monitor_reload_interval = 300
 # Will only work with ZoneMinder version 1.31.2 or greater (default: 0).
 read_alarm_cause = 0
 # Tag event IDs with the alarm (default: 0).

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -29,7 +29,7 @@ verbose = 1
 event_check_interval = 5
 # Interval, in seconds, to reload known monitors (default: 300).
 monitor_reload_interval = 300
-# Will only work with ZoneMinder version 1.31.2 or greater (default: 0).
+# Read monitor alarm cause (ZoneMinder >= 1.31.2, default: 0)
 read_alarm_cause = 0
 # Tag event IDs with the alarm (default: 0).
 tag_alarm_event_id = 0

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -1,0 +1,37 @@
+[network]
+# Port for Websockets connection (default: 9000).
+port = 9000
+# Interval, in seconds, after which we will check for new events (default: 5).
+event_check_interval = 5
+# Interval, in seconds, to reload known monitors (default: 300).
+monitor_reload_interval = 300
+
+[auth]
+# Check username/password against ZoneMinder database (default: 1).
+enabled = 1
+# Authentication timeout, in seconds (default: 20).
+timeout = 20
+
+[fcm]
+# Use FCM for messaging (default: 1).
+enabled = 1
+# Auth token store location (default: /var/lib/zmeventnotification/tokens).
+token_file = /var/lib/zmeventnotification/tokens
+
+[ssl]
+# Enable SSL (default: 0).
+enabled = 0
+# Location to SSL cert (no default).
+cert =
+# Location to SSL key (no default).
+key =
+
+[customize]
+# Display messages to console (default: 1).
+log_to_console = 1
+# Will only work with ZoneMinder version 1.31.2 or greater (default: 0).
+read_alarm_cause = 0
+# Tag event IDs with the alarm (default: 0).
+tag_alarm_event_id = 0
+# Use custom notification sound (default: 1).
+use_custom_notification_sound = 1

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -4,19 +4,19 @@ port = 9000
 
 [auth]
 # Check username/password against ZoneMinder database (default: 1).
-enabled = 1
+enable = 1
 # Authentication timeout, in seconds (default: 20).
 timeout = 20
 
 [fcm]
 # Use FCM for messaging (default: 1).
-enabled = 1
+enable = 1
 # Auth token store location (default: /var/lib/zmeventnotification/tokens).
 token_file = /var/lib/zmeventnotification/tokens
 
 [ssl]
 # Enable SSL (default: 0).
-enabled = 0
+enable = 0
 # Location to SSL cert (no default).
 cert =
 # Location to SSL key (no default).

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -11,6 +11,8 @@ timeout = 20
 [fcm]
 # Use FCM for messaging (default: 1).
 enable = 1
+# FCM API key (no default).
+api_key =
 # Auth token store location (default: /var/lib/zmeventnotification/tokens).
 token_file = /var/lib/zmeventnotification/tokens
 

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -24,7 +24,7 @@ key =
 
 [customize]
 # Display messages to console (default: 1).
-log_to_console = 1
+verbose = 1
 # Interval, in seconds, after which we will check for new events (default: 5).
 event_check_interval = 5
 # Interval, in seconds, to reload known monitors (default: 300).

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -119,8 +119,8 @@ Usage: zmeventnotification.pl [OPTION]...
   --fcm-api-key=KEY                   API key for FCM.
   --token-file=FILE                   Auth token store location (default: /var/lib/zmeventnotification/tokens).
 
-  --enable-ssl                        Enable SSL (default: false).
-  --no-enable-ssl                     Disable SSL (default: true).
+  --enable-ssl                        Enable SSL (default: true).
+  --no-enable-ssl                     Disable SSL (default: false).
   --ssl-cert-file=FILE                Location to SSL cert file.
   --ssl-key-file=FILE                 Location to SSL key file.
 
@@ -205,7 +205,7 @@ $use_fcm     //= $config->val("fcm", "enable",     1);
 $fcm_api_key //= $config->val("fcm", "api_key");
 $token_file  //= $config->val("fcm", "token_file", "/var/lib/zmeventnotification/tokens");
 
-$ssl_enabled   //= $config->val("ssl", "enable", 0);
+$ssl_enabled   //= $config->val("ssl", "enable", 1);
 $ssl_cert_file //= $config->val("ssl", "cert");
 $ssl_key_file  //= $config->val("ssl", "key");
 

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -122,8 +122,8 @@ Usage: zmeventnotification.pl [OPTION]...
   --ssl-cert-file=FILE                Location to SSL cert file.
   --ssl-key-file=FILE                 Location to SSL key file.
 
-  --verbose                           Display messages to console (default: true).
-  --no-verbose                        Don't display messages to console (default: false).
+  --verbose                           Display messages to console (default: false).
+  --no-verbose                        Don't display messages to console (default: true).
   --event-check-interval=SECONDS      Interval, in seconds, after which we will check for new events (default: 5).
   --monitor-reload-interval=SECONDS   Interval, in seconds, to reload known monitors (default: 300).
   --read-alarm-cause                  Read monitor alarm cause (ZoneMinder >= 1.31.2, default: false).
@@ -205,7 +205,7 @@ $ssl_enabled   //= $config->val("ssl", "enable", 0);
 $ssl_cert_file //= $config->val("ssl", "cert");
 $ssl_key_file  //= $config->val("ssl", "key");
 
-$verbose                       //= $config->val("customize", "verbose",                       1);
+$verbose                       //= $config->val("customize", "verbose",                       0);
 $event_check_interval          //= $config->val("customize", "event_check_interval",          5);
 $monitor_reload_interval       //= $config->val("customize", "monitor_reload_interval",       300);
 $read_alarm_cause              //= $config->val("customize", "read_alarm_cause",              0);

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -43,6 +43,7 @@
 
 use File::Basename;
 use Config::IniFiles;
+use Getopt::Long;
 
 use strict;
 use bytes;
@@ -66,8 +67,18 @@ my $app_version="0.98.5";
 #
 # ==========================================================================
 
-my $config_file_path = "/etc/zmeventnotification.ini";
-my $config_file_present = -e $config_file_path;
+my $config_file_path;
+my $config_file_present;
+
+GetOptions("config=s" => \$config_file_path);
+
+if (! $config_file_path) {
+  $config_file_path = "/etc/zmeventnotification.ini";
+  $config_file_present = -e $config_file_path;
+} else {
+  die("$config_file_path does not exist!\n") if ! -e $config_file_path;
+  $config_file_present = 1;
+}
 
 my $config;
 

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -85,8 +85,6 @@ if ($config_file_present) {
 }
 
 my $port                    = $config->val("server", "port",                    9000);
-my $event_check_interval    = $config->val("server", "event_check_interval",    5);
-my $monitor_reload_interval = $config->val("server", "monitor_reload_interval", 300);
 
 my $auth_enabled = $config->val("auth", "enabled", 1);
 my $auth_timeout = $config->val("auth", "timeout", 20);
@@ -99,6 +97,8 @@ my $ssl_cert_file = $config->val("ssl", "cert");
 my $ssl_key_file  = $config->val("ssl", "key");
 
 my $log_to_console                = $config->val("customize", "log_to_console",                1);
+my $event_check_interval          = $config->val("customize", "event_check_interval",          5);
+my $monitor_reload_interval       = $config->val("customize", "monitor_reload_interval",       300);
 my $read_alarm_cause              = $config->val("customize", "read_alarm_cause",              0);
 my $tag_alarm_event_id            = $config->val("customize", "tag_alarm_event_id",            0);
 my $use_custom_notification_sound = $config->val("server",    "use_custom_notification_sound", 1);

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -74,6 +74,7 @@ use constant DEFAULT_CONFIG_FILE_PATH => "/etc/zmeventnotification.ini";
 
 my $config_file_path;
 my $config_file_present;
+my $check_config;
 
 my $port;
 
@@ -98,6 +99,7 @@ my $use_custom_notification_sound;
 
 GetOptions(
   "config=s"                      => \$config_file_path,
+  "check-config"                  => \$check_config,
 
   "port=i"                        => \$port,
 
@@ -186,7 +188,7 @@ sub value_or_undefined {
   return $_[0] || "(undefined)";
 }
 
-if ($log_to_console) {
+sub print_config {
   my $abs_config_file_path = File::Spec->rel2abs($config_file_path);
 
   print(<<"EOF"
@@ -219,6 +221,9 @@ Use custom notification sound . ${\(true_or_false($use_custom_notification_sound
 EOF
   )
 }
+
+exit(print_config()) if $check_config;
+print_config() if $log_to_console;
 
 # This part makes sure we have the righ deps
 if (!try_use ("Net::WebSocket::Server")) {Fatal ("Net::WebSocket::Server missing");exit (-1);}

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -88,7 +88,7 @@ my $ssl_enabled;
 my $ssl_cert_file;
 my $ssl_key_file;
 
-my $log_to_console;
+my $verbose;
 my $event_check_interval;
 my $monitor_reload_interval;
 my $read_alarm_cause;
@@ -112,7 +112,7 @@ GetOptions(
   "ssl-cert-file=s"               => \$ssl_cert_file,
   "ssl-key-file=s"                => \$ssl_key_file,
 
-  "log-to-console"                => \$log_to_console,
+  "verbose"                       => \$verbose,
   "event-check-interval=i"        => \$event_check_interval,
   "monitor-reload-interval=i"     => \$monitor_reload_interval,
   "read-alarm-cause"              => \$read_alarm_cause,
@@ -163,7 +163,7 @@ $ssl_enabled   //= $config->val("ssl", "enable", 0);
 $ssl_cert_file //= $config->val("ssl", "cert");
 $ssl_key_file  //= $config->val("ssl", "key");
 
-$log_to_console                //= $config->val("customize", "log_to_console",                1);
+$verbose                       //= $config->val("customize", "verbose",                       1);
 $event_check_interval          //= $config->val("customize", "event_check_interval",          5);
 $monitor_reload_interval       //= $config->val("customize", "monitor_reload_interval",       300);
 $read_alarm_cause              //= $config->val("customize", "read_alarm_cause",              0);
@@ -213,7 +213,7 @@ SSL enabled ................... ${\(true_or_false($ssl_enabled))}
 SSL cert file ................. ${\(value_or_undefined($ssl_cert_file))}
 SSL key file .................. ${\(value_or_undefined($ssl_key_file))}
 
-Log to console ................ ${\(true_or_false($log_to_console))}
+Log to console ................ ${\(true_or_false($verbose))}
 Read alarm cause .............. ${\(true_or_false($read_alarm_cause))}
 Tag alarm event id ............ ${\(true_or_false($tag_alarm_event_id))}
 Use custom notification sound . ${\(true_or_false($use_custom_notification_sound))}
@@ -223,7 +223,7 @@ EOF
 }
 
 exit(print_config()) if $check_config;
-print_config() if $log_to_console;
+print_config() if $verbose;
 
 # This part makes sure we have the righ deps
 if (!try_use ("Net::WebSocket::Server")) {Fatal ("Net::WebSocket::Server missing");exit (-1);}
@@ -335,7 +335,7 @@ sub printdbg
 {
 	my $a = shift;
     my $now = strftime('%Y-%m-%d,%H:%M:%S',localtime);
-    print($now," ",$a, "\n") if $log_to_console;
+    print($now," ",$a, "\n") if $verbose;
 }
 
 # This function uses shared memory polling to check if 

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -213,7 +213,7 @@ SSL enabled ................... ${\(true_or_false($ssl_enabled))}
 SSL cert file ................. ${\(value_or_undefined($ssl_cert_file))}
 SSL key file .................. ${\(value_or_undefined($ssl_key_file))}
 
-Log to console ................ ${\(true_or_false($verbose))}
+Verbose ....................... ${\(true_or_false($verbose))}
 Read alarm cause .............. ${\(true_or_false($read_alarm_cause))}
 Tag alarm event id ............ ${\(true_or_false($tag_alarm_event_id))}
 Use custom notification sound . ${\(true_or_false($use_custom_notification_sound))}

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -84,6 +84,7 @@ my $auth_enabled;
 my $auth_timeout;
 
 my $use_fcm;
+my $fcm_api_key;
 my $token_file;
 
 my $ssl_enabled;
@@ -115,6 +116,7 @@ Usage: zmeventnotification.pl [OPTION]...
 
   --enable-fcm                        Use FCM for messaging (default: true).
   --no-enable-fcm                     Don't use FCM for messaging (default: false).
+  --fcm-api-key=KEY                   API key for FCM.
   --token-file=FILE                   Auth token store location (default: /var/lib/zmeventnotification/tokens).
 
   --enable-ssl                        Enable SSL (default: false).
@@ -146,6 +148,7 @@ GetOptions(
   "enable-auth!"                   => \$auth_enabled,
 
   "enable-fcm!"                    => \$use_fcm,
+  "fcm-api-key=s"                  => \$fcm_api_key,
   "token-file=s"                   => \$token_file,
 
   "enable-ssl!"                    => \$ssl_enabled,
@@ -198,8 +201,9 @@ $port //= $config->val("network", "port", 9000);
 $auth_enabled //= $config->val("auth", "enable",  1);
 $auth_timeout //= $config->val("auth", "timeout", 20);
 
-$use_fcm    //= $config->val("fcm", "enable",     1);
-$token_file //= $config->val("fcm", "token_file", "/var/lib/zmeventnotification/tokens");
+$use_fcm     //= $config->val("fcm", "enable",     1);
+$fcm_api_key //= $config->val("fcm", "api_key");
+$token_file  //= $config->val("fcm", "token_file", "/var/lib/zmeventnotification/tokens");
 
 $ssl_enabled   //= $config->val("ssl", "enable", 0);
 $ssl_cert_file //= $config->val("ssl", "cert");
@@ -230,6 +234,10 @@ sub value_or_undefined {
   return $_[0] || "(undefined)";
 }
 
+sub present_or_not {
+  return $_[0] ? "(defined)" : "(undefined)";
+}
+
 sub print_config {
   my $abs_config_file_path = File::Spec->rel2abs($config_file_path);
 
@@ -249,6 +257,7 @@ Auth enabled .................. ${\(true_or_false($auth_enabled))}
 Auth timeout .................. ${\(value_or_undefined($auth_timeout))}
 
 Use FCM ....................... ${\(true_or_false($use_fcm))}
+FCM API key ................... ${\(present_or_not($fcm_api_key))}
 Token file .................... ${\(value_or_undefined($token_file))}
 
 SSL enabled ................... ${\(true_or_false($ssl_enabled))}
@@ -586,7 +595,7 @@ sub sendOverFCM
     $obj->{badge}++;
     my $uri = "https://fcm.googleapis.com/fcm/send";
     my $json;
-    my $key="key=AAAApYcZ0mA:APA91bG71SfBuYIaWHJorjmBQB3cAN7OMT7bAxKuV3ByJ4JiIGumG6cQw0Bo6_fHGaWoo4Bl-SlCdxbivTv5Z-2XPf0m86wsebNIG15pyUHojzmRvJKySNwfAHs7sprTGsA_SIR_H43h";
+    my $key="key=" . $fcm_api_key;
 
     
     if ($obj->{platform} eq "ios")

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -84,7 +84,7 @@ if ($config_file_present) {
   $config = Config::IniFiles->new;
 }
 
-my $port                    = $config->val("server", "port",                    9000);
+my $port = $config->val("network", "port", 9000);
 
 my $auth_enabled = $config->val("auth", "enabled", 1);
 my $auth_timeout = $config->val("auth", "timeout", 20);
@@ -101,7 +101,7 @@ my $event_check_interval          = $config->val("customize", "event_check_inter
 my $monitor_reload_interval       = $config->val("customize", "monitor_reload_interval",       300);
 my $read_alarm_cause              = $config->val("customize", "read_alarm_cause",              0);
 my $tag_alarm_event_id            = $config->val("customize", "tag_alarm_event_id",            0);
-my $use_custom_notification_sound = $config->val("server",    "use_custom_notification_sound", 1);
+my $use_custom_notification_sound = $config->val("customize", "use_custom_notification_sound", 1);
 
 my %ssl_push_opts = ();
 

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -72,6 +72,8 @@ use constant DEFAULT_CONFIG_FILE_PATH => "/etc/zmeventnotification.ini";
 
 # Declare options.
 
+my $help;
+
 my $config_file_path;
 my $config_file_present;
 my $check_config;
@@ -97,7 +99,45 @@ my $use_custom_notification_sound;
 
 # Fetch whatever options are available from CLI arguments.
 
+use constant USAGE => <<'USAGE';
+
+Usage: zmeventnotification.pl [OPTION]...
+
+  --help                              Print this page.
+
+  --config=FILE                       Read options from configuration file (default: /etc/zmeventnotification.pl).
+  --check-config                      Print configuration and exit.
+
+  --port=PORT                         Port for Websockets connection (default: 9000).
+
+  --enable-auth                       Check username/password against ZoneMinder database (default: true).
+  --no-enable-auth                    Don't check username/password against ZoneMinder database (default: false).
+
+  --enable-fcm                        Use FCM for messaging (default: true).
+  --no-enable-fcm                     Don't use FCM for messaging (default: false).
+  --token-file=FILE                   Auth token store location (default: /var/lib/zmeventnotification/tokens).
+
+  --enable-ssl                        Enable SSL (default: false).
+  --no-enable-ssl                     Disable SSL (default: true).
+  --ssl-cert-file=FILE                Location to SSL cert file.
+  --ssl-key-file=FILE                 Location to SSL key file.
+
+  --verbose                           Display messages to console (default: true).
+  --no-verbose                        Don't display messages to console (default: false).
+  --event-check-interval=SECONDS      Interval, in seconds, after which we will check for new events (default: 5).
+  --monitor-reload-interval=SECONDS   Interval, in seconds, to reload known monitors (default: 300).
+  --read-alarm-cause                  Read monitor alarm cause (ZoneMinder >= 1.31.2, default: false).
+  --no-read-alarm-cause               Don't read monitor alarm cause (default: true).
+  --tag-alarm-event-id                Tag event IDs with the alarm (default: false).
+  --no-tag-alarm-event-id             Don't tag event IDs with the alarm (default: true).
+  --use-custom-notification-sound     Use custom notification sound (default: true).
+  --no-use-custom-notification-sound  Don't use custom notification sound (default: false).
+
+USAGE
+
 GetOptions(
+  "help"                           => \$help,
+
   "config=s"                       => \$config_file_path,
   "check-config"                   => \$check_config,
 
@@ -119,6 +159,8 @@ GetOptions(
   "tag-alarm-event-id!"            => \$tag_alarm_event_id,
   "use-custom-notification-sound!" => \$use_custom_notification_sound
 );
+
+exit(print(USAGE)) if $help;
 
 # Read options from a configuration file.  If --config is specified, try to
 # read it and fail if it can't be read.  Otherwise, try the default

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -98,26 +98,26 @@ my $use_custom_notification_sound;
 # Fetch whatever options are available from CLI arguments.
 
 GetOptions(
-  "config=s"                      => \$config_file_path,
-  "check-config"                  => \$check_config,
+  "config=s"                       => \$config_file_path,
+  "check-config"                   => \$check_config,
 
-  "port=i"                        => \$port,
+  "port=i"                         => \$port,
 
-  "enable-auth!"                  => \$auth_enabled,
+  "enable-auth!"                   => \$auth_enabled,
 
-  "enable-fcm!"                   => \$use_fcm,
-  "token-file=s"                  => \$token_file,
+  "enable-fcm!"                    => \$use_fcm,
+  "token-file=s"                   => \$token_file,
 
-  "enable-ssl!"                   => \$ssl_enabled,
-  "ssl-cert-file=s"               => \$ssl_cert_file,
-  "ssl-key-file=s"                => \$ssl_key_file,
+  "enable-ssl!"                    => \$ssl_enabled,
+  "ssl-cert-file=s"                => \$ssl_cert_file,
+  "ssl-key-file=s"                 => \$ssl_key_file,
 
-  "verbose"                       => \$verbose,
-  "event-check-interval=i"        => \$event_check_interval,
-  "monitor-reload-interval=i"     => \$monitor_reload_interval,
-  "read-alarm-cause"              => \$read_alarm_cause,
-  "tag-alarm-event-id"            => \$tag_alarm_event_id,
-  "use-custom-notification-sound" => \$use_custom_notification_sound
+  "verbose!"                       => \$verbose,
+  "event-check-interval=i"         => \$event_check_interval,
+  "monitor-reload-interval=i"      => \$monitor_reload_interval,
+  "read-alarm-cause!"              => \$read_alarm_cause,
+  "tag-alarm-event-id!"            => \$tag_alarm_event_id,
+  "use-custom-notification-sound!" => \$use_custom_notification_sound
 );
 
 # Read options from a configuration file.  If --config is specified, try to

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -151,13 +151,13 @@ if ($config_file_present) {
 
 $port //= $config->val("network", "port", 9000);
 
-$auth_enabled //= $config->val("auth", "enabled", 1);
+$auth_enabled //= $config->val("auth", "enable",  1);
 $auth_timeout //= $config->val("auth", "timeout", 20);
 
-$use_fcm    //= $config->val("fcm", "enabled",    1);
+$use_fcm    //= $config->val("fcm", "enable",     1);
 $token_file //= $config->val("fcm", "token_file", "/var/lib/zmeventnotification/tokens");
 
-$ssl_enabled   //= $config->val("ssl", "enabled", 0);
+$ssl_enabled   //= $config->val("ssl", "enable", 0);
 $ssl_cert_file //= $config->val("ssl", "cert");
 $ssl_key_file  //= $config->val("ssl", "key");
 


### PR DESCRIPTION
Hey @pliablepixels :wave:

I thought I'd clean up your script and support reading options from a configuration file and CLI params, which frees us from the requirement of editing the source code.  This allows the code to be packaged easier (like [my package in the AUR](https://aur.archlinux.org/packages/zmeventserver-git/)) since the script code should never change, and generally makes it easier to use.

Please thumb around the PR and let me know what you think!  I have a few questions that you might have answers to, too:

- Can ZoneMinder sanely read from `/etc/zmeventnotification.ini`?
- I moved the token store to `/var/lib/zmeventnotification/tokens` to follow [the FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard).  How's this look?
- Will there be more installation steps because of the new libraries for option parsing and reading INI files?
- I haven't tested FCM.  Does it work with the changes?
- Since you mentioned that you deprecated a few things, can some of these options be removed?

Thanks for a great app!  Cheers! :beers: 