### PR TITLE
add mqtt support for home assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Here is how to debug and report:
 * Enable Debug logs in zmNinja (Setting->Developer Options->Enable Debug Log)
 * telnet/ssh into your zoneminder server
 * Stop the zmeventnotification doing `sudo zmdc.pl status zmeventnotification.pl`
-* Make sure there are no stale processes running of zmeventnotification by doing `ps -aef | grep zmeventnotification` and making sure it doesn't show existing processes
+* Make sure there are no stale processes running of zmeventnotification by doing `ps -aef | grep zmeventnotification` and making sure it doesn't show existing processes (ignore the one that says `grep <something>`)
 * Start a terminal (lets call it Terminal-Log)  to tail logs like so `tail -f /var/log/syslog | grep zmeventnotification`
 * Edit `zmeventnotification.ini` (typically in `/etc/`) and make sure `verbose = 1` is set. This will print more logs on the console. Make sure you turn this off again before switching back to daemon mode.
 * Start another terminal and start zmeventserver manually from command line like so `sudo /usr/bin/zmeventnotification.pl`
@@ -343,16 +343,17 @@ Oct 20 10:28:56 homeserver zmeventnotification[27789]: INF [Pushproxy push messa
 ```
 
 * If you are debugging problems with receiving push notifications on zmNinja mobile, then replicate the following scenario:
+    * Run the event server in manual mode as described above
     * Kill zmNinja
     * Start zmNinja
     * At this point, in the `zmeventnotification` logs you should registration messages (refer to logs example above). If you don't you've either not configured zmNinja to use the eventserver, or it can't reach the eventserver (very common problem)
     * Next up, make sure you are not running zmNinja in the foreground (move it to background or kill it). When zmNinja is in the foreground, it uses websockets to get notifications
     * Force an alarm like I described above. If you don't see logs in `zmeventnotification` saying "Sending notification over PushProxy" then the eventserver, for some reason, does not have your app token. Inspeced `tokens.txt` (typically in `/etc/`) to make sure an entry for your phone exists
     * If you see that message, but your mobile phone is not receiving a push notification:
-        * Make sure you haven't disable push notifications on your phone (lots of people do this by mistake and wonder why)
-        * Make sure you haven't muted notifications (again, lots of people...)
-        * Sometimes, the push servers of Apple and Google stop forwarding messages for a day or two. I have no idea why. Give it a day or two?
-        * Open up zmNinja, go right to logs and send it to me 
+     * Make sure you haven't disable push notifications on your phone (lots of people do this by mistake and wonder why)
+     * Make sure you haven't muted notifications (again, lots of people...)
+     * Sometimes, the push servers of Apple and Google stop forwarding messages for a day or two. I have no idea why. Give it a day or two?
+     * Open up zmNinja, go right to logs and send it to me 
 
 * If you have issues, please send me a copy of your zmeventserver logs generated above from Terminal-Log, as well as zmNinja debug logs
 

--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -27,9 +27,18 @@ enable = 1
 # Auth token store location (default: /etc/private/tokens.txt).
 # token_file = /your/path/filename
 
+
+[mqtt]
+# Enable MQTT broadcast, it will brocast to a topic called zoneminder/monitor_id (default: 0)
+enable = 1
+
+# MQTT server to send messages to (default: 127.0.0.1)
+server = 192.168.100.2
+
+
 [ssl]
 # Enable SSL (default: 1).
-enable = 1
+enable = 0
 
 # Location to SSL cert (no default).
 cert = /etc/apache2/ssl/zoneminder.crt

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -71,6 +71,8 @@ use constant DEFAULT_ADDRESS => '[::]';
 use constant DEFAULT_AUTH_ENABLE => 1;
 use constant DEFAULT_AUTH_TIMEOUT => 20;
 use constant DEFAULT_FCM_ENABLE => 1;
+use constant DEFAULT_MQTT_ENABLE => 0;
+use constant DEFAULT_MQTT_SERVER => '127.0.0.1';
 use constant DEFAULT_FCM_TOKEN_FILE => '/etc/private/tokens.txt';
 use constant DEFAULT_SSL_ENABLE => 1;
 
@@ -96,6 +98,9 @@ my $address;
 my $auth_enabled;
 my $auth_timeout;
 
+my $use_mqtt;
+my $mqtt_server; 
+
 my $use_fcm;
 my $fcm_api_key;
 my $token_file;
@@ -117,6 +122,8 @@ use constant NINJA_API_KEY => "AAAApYcZ0mA:APA91bG71SfBuYIaWHJorjmBQB3cAN7OMT7bA
 my $dummyEventTest = 0; # if on, will generate dummy events. Not in config for a reason. Only dev testing
 my $dummyEventInterval = 30; # timespan to generate events in seconds
 my $dummyEventTimeLastSent = time();
+
+my $mqttServer = '192.168.100.2';
 
 # This part makes sure we have the right deps
 if (!try_use ("Net::WebSocket::Server")) {Fatal ("Net::WebSocket::Server missing");}
@@ -184,6 +191,9 @@ GetOptions(
   "address=s"                      => \$address,
 
   "enable-auth!"                   => \$auth_enabled,
+  
+  "enable-mqtt!"                    => \$use_mqtt,
+  "mqtt-server=s"                  => \$mqtt_server,
 
   "enable-fcm!"                    => \$use_fcm,
   "fcm-api-key=s"                  => \$fcm_api_key,
@@ -244,6 +254,9 @@ $address //= config_get_val($config, "network", "address", DEFAULT_ADDRESS);
 
 $auth_enabled //= config_get_val($config, "auth", "enable",  DEFAULT_AUTH_ENABLE);
 $auth_timeout //= config_get_val($config, "auth", "timeout", DEFAULT_AUTH_TIMEOUT);
+
+$use_mqtt    //= config_get_val($config, "mqtt", "enable",     DEFAULT_MQTT_ENABLE);
+$mqtt_server  //= config_get_val($config, "mqtt", "server",    DEFAULT_MQTT_SERVER);
 
 $use_fcm     //= config_get_val($config, "fcm", "enable",     DEFAULT_FCM_ENABLE);
 $fcm_api_key //= config_get_val($config, "fcm", "api_key", NINJA_API_KEY);
@@ -410,6 +423,14 @@ if ($use_fcm)
         mkdir $dir;
     }
 }
+
+if ($use_mqtt)
+{
+    if (!try_use ("Net::MQTT::Simple")) {Fatal ("Net::MQTT::Simple  missing");exit (-1);}
+    Info ("Broadcasting Events to MQTT");
+
+}
+
 
 Info( "Event Notification daemon v $app_version starting\n" );
 loadTokens();
@@ -643,6 +664,29 @@ sub deleteToken
     }
     close ($fh);
 }
+
+
+# Sends a push notification to the mqtt Broker
+sub sendOverMQTTBroker
+{
+
+    my ($header, $mid) = @_;
+    my $json;
+
+    $json = encode_json ({
+                monitor=> $mid,
+                name=>$header,
+                state => 'alarm',
+            });
+
+    Debug ("Final JSON being sent is: $json");
+
+    my $mqtt = Net::MQTT::Simple->new($mqtt_server);
+
+    $mqtt->publish(join('/','zoneminder',$mid) => $json);
+}
+
+
 
 
 # Sends a push notification to FCM
@@ -1401,6 +1445,11 @@ sub initSocketServer
             my $ac = scalar @active_connections;
             if (checkEvents())
             {
+		if ($use_mqtt) {
+                    Info ("Sending notification over MQTT");
+                    sendOverMQTTBroker($alarm_header, $alarm_mid);
+                }
+
                 Info ("Broadcasting new events to all $ac websocket clients\n");
                     my ($serv) = @_;
                     my $i = 0;


### PR DESCRIPTION
Home Assistant's web sockets adapter isn't great which means it cant do an auth and then establish a socket, at least I haven't been able to figure out yet how to do it. in an ideal world thats how I would have integrated. 

So I added the ability to publish messages to a MQTT topic and have other listeners listen on that bridge. adding a PR to see what you think about adding it back to the mainline? MQTT is quite mainstream when it comes to IoT and automation so might be a worthwhile PR. 

This then allows for complex logic when an alarm triggers and capturing an image from the camera and adding it to the notification etc. 

