### PR TITLE
63 pass alarm cause to hook

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -1750,7 +1750,7 @@ sub processAlarms {
         # if you want to use hook, lets first call the hook
         # if the hook returns an exit value of 0 (yes/success), we process it, else we skip it
         if ($hook) {
-            my $cmd = $hook." ".$alarm->{EventId}." ".$alarm->{MonitorId}." \"".$alarm->{Name}."\"";
+            my $cmd = $hook." ".$alarm->{EventId}." ".$alarm->{MonitorId}." \"".$alarm->{Name}."\""." \"".$alarm->{Cause}."\"";
             printInfo ("Invoking hook:".$cmd);
             my $resTxt = `$cmd`;
             my $resCode = $? >> 8;

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -1756,13 +1756,13 @@ sub processAlarms {
             my $resCode = $? >> 8;
             chomp($resTxt);
             printInfo("hook script returned with text:".$resTxt." exit:".$resCode);
-            next if ($resCode !=0);
             if ($use_hook_description) {
               
                 $alarm->{Cause} = $resTxt;
                 # This updated the ZM DB with the detected description
                 print WRITER "event_description--TYPE--".$alarm->{MonitorId}."--SPLIT--".$resTxt."\n";
             }
+            next if ($resCode !=0);
             
         }
         # coming here means the alarm needs to be sent out to listerens who are interested

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -1756,13 +1756,14 @@ sub processAlarms {
             my $resCode = $? >> 8;
             chomp($resTxt);
             printInfo("hook script returned with text:".$resTxt." exit:".$resCode);
+	    next if ($resCode !=0);
             if ($use_hook_description) {
               
                 $alarm->{Cause} = $resTxt;
                 # This updated the ZM DB with the detected description
                 print WRITER "event_description--TYPE--".$alarm->{MonitorId}."--SPLIT--".$resTxt."\n";
             }
-            next if ($resCode !=0);
+           
             
         }
         # coming here means the alarm needs to be sent out to listerens who are interested


### PR DESCRIPTION
My changes to have the alarm cause to be passed to the hook script.

I also added a change that allows the event description from the hook to be used even when the hook indicates that no notification should be sent.