### PR TITLE
WEB_OWNER and WEB_GROUP defaults from environment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,10 +21,10 @@ TARGET_CONFIG='/etc/zm'
 TARGET_DATA='/var/lib/zmeventnotification'
 
 WGET=$(which wget)
-WEB_OWNER=$(ps xao user,group,comm | grep -E '(httpd|hiawatha|apache|apache2|nginx)' | grep -v whoami | grep -v root | head -n1 | awk '{print $1}')
+WEB_OWNER_FROM_PS=$(ps xao user,group,comm | grep -E '(httpd|hiawatha|apache|apache2|nginx)' | grep -v whoami | grep -v root | head -n1 | awk '{print $1}')
 #WEB_OWNER='www-data' # uncomment this if the above mechanism fails
 
-WEB_GROUP=$(ps xao user,group,comm | grep -E '(httpd|hiawatha|apache|apache2|nginx)' | grep -v whoami | grep -v root | head -n1 | awk '{print $2}')
+WEB_GROUP_FROM_PS=$(ps xao user,group,comm | grep -E '(httpd|hiawatha|apache|apache2|nginx)' | grep -v whoami | grep -v root | head -n1 | awk '{print $2}')
 #WEB_GROUP='www-data' # uncomment if above line fails
 # make this empty if you don't want backups
 MAKE_CONFIG_BACKUP='-b'
@@ -32,7 +32,12 @@ MAKE_CONFIG_BACKUP='-b'
 # --- end of change these ---
 
 # set default values 
+# if we have a value from ps use it, otherwise look in env
+WEB_OWNER=${WEB_OWNER_FROM_PS:-$WEB_OWNER}
+WEB_GROUP=${WEB_GROUP_FROM_PS:-$WEB_GROUP}
+# if we don't have a value from ps or env, use default
 WEB_OWNER=${WEB_OWNER:-www-data}
+WEB_GROUP=${WEB_GROUP:-www-data}
 WGET=${WGET:-/usr/bin/wget}
 
 


### PR DESCRIPTION
Use values from environment variables for WEB_OWNER and WEB_GROUP if values cannot be obtained from running ps.  This provides the capability to set these variables in an scripted build, where the values cannot be determined by ps since there is no running system.

Also added default value for WEB_GROUP.