### PR TITLE
forgotten space

### DIFF
--- a/hook/detect.py
+++ b/hook/detect.py
@@ -228,7 +228,7 @@ else:
         if matched_file == filename1:
             prefix = '[a] '  # we will first analyze alarm
         else:
-            prefix = '[s]'
+            prefix = '[s] '
     else:
         prefix = '[x] '
 


### PR DESCRIPTION
zmeventnotification.pl would remove the 'd' from 'detected:' when stripping the prefix of '[s]' since there was no extra space as with the other ones.