### PR TITLE
Update zmeventnotification.pl

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -842,7 +842,7 @@ sub sendOverMQTTBroker
    # based on the library docs, if this fails, it will try and reconnect 
    # before the next message is sent (with a retry timer of 5 s)
    $ac->{mqtt_conn}->publish(join('/','zoneminder',$alarm->{MonitorId}) => $json);
-    
+   $ac->{mqtt_conn}->disconnect();
 
 }
 


### PR DESCRIPTION
This prevents errors on the MQTT broker, such as Socket error on client , disconnecting, after every publish for every event.
It goes from:
Socket error on client Net::MQTT::Simple[DLRJQDONHE], disconnecting.
To:
Client Net::MQTT::Simple[DLRJQDONHE] disconnected.