### PR TITLE
proper pip3 version import

### DIFF
--- a/hook/detect.py
+++ b/hook/detect.py
@@ -139,7 +139,7 @@ for model in g.config['models']:
         try:
             import zmes_hook_helpers.face as face
         except ImportError:
-            g.logger.error ('Error importing face recognition. Make sure you did sudo -H pip install face_recognition')
+            g.logger.error ('Error importing face recognition. Make sure you did sudo -H pip3 install face_recognition')
             raise
 
         m = face.Face(upsample_times=g.config['face_upsample_times'], 


### PR DESCRIPTION
there is a misleading error in the logs regarding pip version
Error importing face recognition. Make sure you did sudo -H pip install face_recognition
the proper command is: sudo -H pip3 install face_recognition 

