### PR TITLE
fix: TypeError: Object of type ndarray is not JSON serializable

### DIFF
--- a/hook/detect.py
+++ b/hook/detect.py
@@ -243,7 +243,7 @@ for model in g.config['models']:
                         obj_json.append( {
                             'type': 'object',
                             'label': t_l,
-                            'box':  b[idx],
+                            'box':  b[idx].tolist(),
                             'confidence': c[idx]
                         })
                     # Now add plate objects
@@ -255,7 +255,7 @@ for model in g.config['models']:
                         obj_json.append( {
                             'type': 'licenseplate',
                             'label': al,
-                            'box': alpr_b[i],
+                            'box': alpr_b[i].tolist(),
                             'confidence': alpr_c[i]
                         })
                 elif filename == filename1 and filename2: # no plates, but another image to try
@@ -281,7 +281,7 @@ for model in g.config['models']:
                             obj_json.append( {
                                 'type': 'object',
                                 'label': t_l,
-                                'box': b[idx],
+                                'box': b[idx].tolist(),
                                 'confidence': c[idx]
                             })
                     try_next_image = False
@@ -314,7 +314,7 @@ for model in g.config['models']:
                         obj_json.append({
                             'type': 'object',
                             'label': t_l,
-                            'box': b[idx],
+                            'box': b[idx].tolist(),
                             'confidence': c[idx]
                         })
         else: # usealpr
@@ -324,7 +324,7 @@ for model in g.config['models']:
                 obj_json.append( {
                     'type': 'object',
                     'label': t_l,
-                    'box': b[idx],
+                    'box': b[idx].tolist(),
                     'confidence': c[idx]
                 })
         if b:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/detect.py", line 400, in <module>
    json.dump(final_json,jo)
  File "/usr/lib/python3.7/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/usr/lib/python3.7/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.7/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.7/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ndarray is not JSON serializable
