### PR TITLE
Change default listen address to IPv4 all interfaces

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -77,7 +77,7 @@ my $app_version="4.4";
 use constant {
     DEFAULT_CONFIG_FILE       => "/etc/zm/zmeventnotification.ini",
     DEFAULT_PORT              => 9000,
-    DEFAULT_ADDRESS           => '[::]',
+    DEFAULT_ADDRESS           => '0.0.0.0',
     DEFAULT_AUTH_ENABLE       => 'yes',
     DEFAULT_AUTH_TIMEOUT      => 20,
     DEFAULT_FCM_ENABLE        => 'yes',


### PR DESCRIPTION
So I noticed in my testing that when SSL was enabled the events notification server did not listen on the defined port, but rather would bind to a random port on each start up. After much head scratching and investigation I noticed that the issue was having an invalid address caused `IO::Socket::SSL` to bind to a random port. Removing the address or changing it to `0.0.0.0` fixed the issue. I did then eventually see the [comment in zmeventnotification.ini](https://github.com/pliablepixels/zmeventnotification/blob/master/zmeventnotification.ini#L14) stating the same thing. However surely it makes more sense for the default value to be workable?

For further information, I did test many other variations of IPv6 defaults but none worked. I read the docs for `IO::Socket::SSL` and it states the following:

> IO::Socket::SSL inherits from another IO::Socket module. The choice of the super class depends on the installed modules:
> 1. If IO::Socket::IP with at least version 0.20 is installed it will use this module as super class, transparently providing IPv6 and IPv4 support.
> 2. If IO::Socket::INET6 is installed it will use this module as super class, transparently providing IPv6 and IPv4 support.
> 3. Otherwise it will fall back to IO::Socket::INET, which is a perl core module. With IO::Socket::INET you only get IPv4 support.

My test environment was running `IO::Socket::IP	0.38` so this should have worked.

```
# cpan -l | grep IO::Socket
IO::Socket::Multicast	1.12
IO::Socket::SSL	2.060
IO::Socket::SSL::PublicSuffix	undef
IO::Socket::SSL::Utils	2.014
IO::Socket::SSL::Intercept	2.056
IO::Socket	1.38
IO::Socket::UNIX	1.26
IO::Socket::INET	1.35
IO::Socket::IP	0.38
```

Overall, I think defaulting to 0.0.0.0 will be a better default for new-comers to this project.