### PR TITLE
Fix typo in version option handling

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -280,7 +280,7 @@ GetOptions(
   'check-config' => \$check_config,
 );
 
-if ($app_version) {
+if ($version) {
   print($app_version);
   exit(0);
 }


### PR DESCRIPTION
There was a typo in commit https://github.com/pliablepixels/zmeventnotification/commit/7bf211a280f03f783a76132db1d8f3572f211a2c that meant that any invocation of `zmeventnotification.pl` will just print the version and exit. This fixes it.