### PR TITLE
add MQTT Retain flag option

### DIFF
--- a/zmeventnotification.ini
+++ b/zmeventnotification.ini
@@ -99,10 +99,8 @@ server = 127.0.0.1
 # Password 
 # password = !MQTT_PASSWORD
 
-# Some MQTT brokers don't seem to honor
-# keep alives resulting in missed notifications
-# default:no
-close_on_send = no
+# Set retain flag on MQTT messages (default: no)
+retain = no
 
 
 [ssl]

--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -88,6 +88,7 @@ use constant {
   DEFAULT_MQTT_ENABLE        => 'no',
   DEFAULT_MQTT_SERVER        => '127.0.0.1',
   DEFAULT_MQTT_TICK_INTERVAL => 15,
+  DEFAULT_MQTT_RETAIN        => 'no',
   DEFAULT_FCM_TOKEN_FILE     => '/var/lib/zmeventnotification/push/tokens.txt',
 
   DEFAULT_USE_API_PUSH => 'no',
@@ -174,6 +175,7 @@ my $mqtt_server;
 my $mqtt_username;
 my $mqtt_password;
 my $mqtt_tick_interval;
+my $mqtt_retain;
 my $mqtt_last_tick_time = time();
 
 my $use_fcm;
@@ -453,6 +455,8 @@ sub loadEsConfigSettings {
   $mqtt_tick_interval =
     config_get_val( $config, 'mqtt', 'tick_interval',
     DEFAULT_MQTT_TICK_INTERVAL );
+  $mqtt_retain =
+    config_get_val( $config, 'mqtt', 'retain', DEFAULT_MQTT_RETAIN );
 
   $use_fcm = config_get_val( $config, 'fcm', 'enable', DEFAULT_FCM_ENABLE );
   $fcm_api_key = config_get_val( $config, 'fcm', 'api_key', NINJA_API_KEY );
@@ -620,6 +624,7 @@ Use MQTT ............................. ${\(yes_or_no($use_mqtt))}
 MQTT Server .......................... ${\(value_or_undefined($mqtt_server))}
 MQTT Username ........................ ${\(value_or_undefined($mqtt_username))}
 MQTT Password ........................ ${\(present_or_not($mqtt_password))}
+MQTT Retain .......................... ${\(yes_or_no($mqtt_retain))}
 MQTT Tick Interval ................... ${\(value_or_undefined($mqtt_tick_interval))}
 
 SSL enabled .......................... ${\(yes_or_no($ssl_enabled))}
@@ -1909,7 +1914,14 @@ sub processJobs {
         printDebug("Job: MQTT Publish on topic: $topic");
         foreach (@active_connections) {
           if ( ( $_->{id} eq $id ) && exists $_->{mqtt_conn} ) {
-            $_->{mqtt_conn}->publish( $topic => $payload );
+            if ( $mqtt_retain ) {
+              printDebug("Job: MQTT Publish with retain");
+              $_->{mqtt_conn}->retain( $topic => $payload );
+            }
+            else {
+              printDebug("Job: MQTT Publish");
+              $_->{mqtt_conn}->publish( $topic => $payload );
+            }
           }
         }
       }


### PR DESCRIPTION
Adds ability to optionally send MQTT messages with the retain flag set.

Adds new .ini setting under the [mqtt] section labelled 'retain' (default: no). If set to yes, then all MQTT messages will be published with the retain flag set, otherwise a normal publish is performed.

With 'retain = no'...
```
1586903452: Received PUBLISH from Net::MQTT::Simple[XHHSITNCMJ] (d0, q0, r0, m0, 'zoneminder/4', ... (144 bytes))
```

With 'retain = yes'...
```
1586903292: Received PUBLISH from Net::MQTT::Simple[CSEVFUQADM] (d0, q0, r1, m0, 'zoneminder/4', ... (144 bytes))
```
