### PR TITLE
Update image_manip.py

### DIFF
--- a/hook/zmes_hook_helpers/image_manip.py
+++ b/hook/zmes_hook_helpers/image_manip.py
@@ -203,7 +203,7 @@ def processPastDetection(bbox, label, conf, mid):
         b = list(zip(it, it))
 
         b.insert(1, (b[1][0], b[0][1]))
-        b.insert(3, (b[0][0], b[1][1]))
+        b.insert(3, (b[0][0], b[2][1]))
         #g.logger.debug ("Past detection: {}@{}".format(saved_ls[idx],b))
         #g.logger.debug ('BOBK={}'.format(b))
         obj = Polygon(b)
@@ -214,7 +214,7 @@ def processPastDetection(bbox, label, conf, mid):
             it = iter(saved_b)
             saved_b = list(zip(it, it))
             saved_b.insert(1, (saved_b[1][0], saved_b[0][1]))
-            saved_b.insert(3, (saved_b[0][0], saved_b[1][1]))
+            saved_b.insert(3, (saved_b[0][0], saved_b[2][1]))
             saved_obj = Polygon(saved_b)
             max_diff_pixels = max_diff_area
 


### PR DESCRIPTION
The existing code was creating a list such as this  [(468, 22), (538, 22), (538, 200), (468, 22)]] for the polygon.  The last element isn't correct as it's the same as the first point and thus isn't really completing the polygon. The value list should contain [(468, 22), (538, 22), (538, 200), (468, 200)].  The modification provided fixes this issue.