### PR TITLE
Object boxing configuration update

### DIFF
--- a/hook/objectconfig.ini
+++ b/hook/objectconfig.ini
@@ -51,6 +51,12 @@ match_past_detections=yes
 # to calculate the difference in areas and based on his tests, 5% worked well. YMMV. Change it if needed.
 past_det_max_diff_area=5%
 
+# If an image is saved in ZM, control if we box all objects detected by Machine Learming or only 
+# the new objects detected in the current image compared to previous image. Default of no to box 
+# all detected objects
+only_box_new_objs=yes.  
+
+
 # sequence of models to run for detection
 
 models=yolo,face

--- a/hook/zmes_hook_helpers/common_params.py
+++ b/hook/zmes_hook_helpers/common_params.py
@@ -69,6 +69,11 @@ config_vals = {
             'default': 'no',
             'type': 'string'
         },
+        'only_box_new_objs':{
+            'section': 'general',
+            'default': 'no',
+            'type': 'string'
+        },
         'past_det_max_diff_area':{
             'section': 'general',
             'default': '5%',


### PR DESCRIPTION
Update to configuration parameter that allows user to either specify the boxing of all objects detected or only the objects that are different from the previous images.  So newly detected objects.