### PR TITLE
Update query parameters in utils.py to fix authentication failure

### DIFF
--- a/hook/zmes_hook_helpers/utils.py
+++ b/hook/zmes_hook_helpers/utils.py
@@ -58,9 +58,11 @@ def str_split(my_str):
 def import_zm_zones(mid, reason):
     match_reason = True if g.config['only_triggered_zm_zones']=='yes' else False
     url = g.config['portal'] + '/api/zones/forMonitor/' + mid + '.json'
-    g.logger.debug('Getting ZM zones using {}?username=xxx&password=yyy'.format(url),level=2)
+    g.logger.debug('Getting ZM zones using {}?username=xxx&password=yyy&user=xxx&pass=yyy'.format(url),level=2)
     url = url + '?username=' + g.config['user']
     url = url + '&password=' + urllib.parse.quote(g.config['password'], safe='')
+    url = url + '&user=' + g.config['user']
+    url = url + '&pass=' + urllib.parse.quote(g.config['password'], safe='')
 
     if g.config['portal'].lower().startswith('https://'):
         main_handler = urllib.request.HTTPSHandler(context=g.ctx)

--- a/hook/zmes_hook_helpers/utils.py
+++ b/hook/zmes_hook_helpers/utils.py
@@ -58,9 +58,9 @@ def str_split(my_str):
 def import_zm_zones(mid, reason):
     match_reason = True if g.config['only_triggered_zm_zones']=='yes' else False
     url = g.config['portal'] + '/api/zones/forMonitor/' + mid + '.json'
-    g.logger.debug('Getting ZM zones using {}?user=xxx&pass=yyy'.format(url),level=2)
-    url = url + '?user=' + g.config['user']
-    url = url + '&pass=' + urllib.parse.quote(g.config['password'], safe='')
+    g.logger.debug('Getting ZM zones using {}?username=xxx&password=yyy'.format(url),level=2)
+    url = url + '?username=' + g.config['user']
+    url = url + '&password=' + urllib.parse.quote(g.config['password'], safe='')
 
     if g.config['portal'].lower().startswith('https://'):
         main_handler = urllib.request.HTTPSHandler(context=g.ctx)


### PR DESCRIPTION
When import_zm_zones is called in utils.py, using 'user' and 'pass' as query parameters fails unless legacy authentication is enabled (tested with ZoneMinder 1.34.16, ZMES 5.15.5).  Using 'username' and 'password' as query parameters works whether or not legacy authentication is enabled in the version tested.  I have updated utils.py to send both username/password and user/pass query parameters to cover all the cases and maintain compatibility with possible past versions.

@danlsgiga noted in his comment that [here](https://github.com/pliablepixels/zmeventnotification/issues/156#issuecomment-648599946) as part of closed issue #156 that this change may be a reversion.  However, the thread suggests that there are versions of zoneminder for which user/pass is appropriate, which is why I have left in both sets of query parameters.