### PR TITLE
correct object_labels value for tinyyolo v3 / v4

### DIFF
--- a/hook/objectconfig.ini
+++ b/hook/objectconfig.ini
@@ -202,14 +202,14 @@ object_labels={{base_data_path}}/models/yolov3/coco.names
 #object_processor=cpu #or gpu
 #object_config={{base_data_path}}/models/tinyyolov3/yolov3-tiny.cfg
 #object_weights={{base_data_path}}/models/tinyyolov3/yolov3-tiny.weights
-#object_labels={{base_data_path}}/models/tinyyolov3/yolov3-tiny.txt
+#object_labels={{base_data_path}}/models/tinyyolov3/coco.names
 
 # For tiny Yolo V4
 #object_framework=opencv
 #object_processor=cpu # or gpu
 #object_config={{base_data_path}}/models/tinyyolov4/yolov4-tiny.cfg
 #object_weights={{base_data_path}}/models/tinyyolov4/yolov4-tiny.weights
-#object_labels={{base_data_path}}/models/tinyyolov4/yolov4-tiny.txt
+#object_labels={{base_data_path}}/models/tinyyolov4/coco.names
 
 
 # config params for HOG


### PR DESCRIPTION
I installed ES yesterday and while initially got it working with yolo, later when when trying v4 and tiny both failed complaining the file does not exist as the config value pointed at a non-existent .txt file.