### PR TITLE
bestmatch_order does not work with speech marks.

### DIFF
--- a/hook/objectconfig.ini
+++ b/hook/objectconfig.ini
@@ -100,7 +100,7 @@ frame_id=bestmatch
 # make the order 's,a'. Don't get imaginative here -
 # 's,a' is the only thing it understands. Everything else
 # means alarm then snapshot.
-#bestmatch_order = 's,a'
+#bestmatch_order = s,a
 
 # this is the to resize the image before analysis is done
 resize=1200


### PR DESCRIPTION
I think the example config needs to be updated. bestmatch_order does not work for me unless speech marks are removed (at least on my ubuntu machine)...