### PR TITLE
Don't crash when old-style passwords are still in use.

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -1615,7 +1615,10 @@ sub validateAuth {
           return 0;
         }
         my $saved_pass = $state->{Password};
-
+	if ($saved_pass =~ /^-ZM-/) {
+		printError("Old-style password set for user '$u'. Change it through the ZM console and try again.");
+		return 0;
+	}
         # perl bcrypt libs can't handle $2b$ or $2y$
         $saved_pass =~ s/^\$2.\$/\$2a\$/;
         my $new_hash = Crypt::Eksblowfish::Bcrypt::bcrypt( $p, $saved_pass );


### PR DESCRIPTION
Fix for #325 

Report an error and suggest a solution instead of crashing when old-style passwords are still in use for event server users.

This is the new error log:
```
CONSOLE DBG-2:2020-10-23,10:04:05 PARENT: ---------->onConnect msg START<--------------
CONSOLE ERR:2020-10-23,10:04:05 PARENT: Old-style password set for user 'admin'. Change it through the ZM console and try again.
10/23/20 10:04:05.244100 zmeventnotification[16430].ERR [main:988] [PARENT: Old-style password set for user 'admin'. Change it through the ZM console and try again.]
CONSOLE DBG-1:2020-10-23,10:04:05 PARENT: marking for deletion - bad authentication provided by ::ffff:210.54.xx.xx
CONSOLE DBG-2:2020-10-23,10:04:05 PARENT: ---------->onConnect msg STOP<--------------
```