### PR TITLE
Fix bug in zmeventnotification.pl

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -4110,6 +4110,7 @@ sub processNewAlarmsInFork {
 
             # This will be prefixed, so no need to add old notes back
             updateEventinZmDB( $eid, $hookString );
+            $notes = $hookString . " " . $notes;
           }
           else {
             printDebug( "DB Event notes contain detection text, all good", 2 );


### PR DESCRIPTION
If hook results are overwritten in ZM (which happens from time to time),
the zm_event_end.sh would be invoked without the hook results. This
patch invokes zm_event_end.sh (and other subsequent scripts) using the
correct notes argument.