### PR TITLE
fix hash corruption in initFCMTokens()

### DIFF
--- a/zmeventnotification.pl
+++ b/zmeventnotification.pl
@@ -2867,7 +2867,7 @@ sub initFCMTokens {
     push @active_connections,
       {
       type         => FCM,
-      id           => gettimeofday(),
+      id           => int scalar gettimeofday(),
       token        => $token,
       state        => INVALID_CONNECTION,
       time         => time(),


### PR DESCRIPTION
In `initFCMTokens` the call to `gettimeofday()` returns a two element array in this context, which then corrupts the `active_connections` element. 
This in turn causes an invalid entry to be written to tokens.txt with an empty token value
e.g.

FCM token entry in `@active_connections`:
```
$VAR1 = \{
          '584809' => 'token',
          ' ' => 'pushstate',
          'id' => 1667001069,
          '1,6,3' => 'intlist',
          '3' => 'time',
          '0' => 'monlist',
          '1667001069' => 'badge',
          'android' => 'extra_fields',
          '30,10,30' => 'last_sent',
          'HASH(0x5640b83ec7b0)' => undef,
          'HASH(0x5640b820ed00)' => 'platform',
          'enabled' => 'appversion',
          'cNQdy3lhT8y0y1x...' => 'state',
          '1.6.009' => 'invocations',
          'type' => 1000
        };
```

tokens.txt:
```
{
  "tokens": {
    "cNQdy3lhT8y0y1x...": {
      "invocations": {
        "at": 9,
        "count": 0
      },
      "intlist": "30,10,30",
      "platform": "android",
      "monlist": "1,6,3",
      "appversion": "1.6.009",
      "pushstate": "enabled"
    },
    "": {                                   <---
      "invocations": {
        "at": 9,
        "count": 0
      }
    }
  }
}
```


Calling `gettimeofday()` in a scalar context produces a much happier looking hash:
```
$VAR1 = \{
            'monlist' => '1,6,3',
            'badge' => 0,
            'type' => 1000,
            'intlist' => '30,10,30',
            'time' => 1667001069,
            'id' => '1667001069',
            'extra_fields' => '',
            'state' => 3,
            'token' => 'cNQdy3lhT8y0y1x...',
            'last_sent' => {},
            'invocations' => {
                               'count' => 0,
                               'at' => 9
                             },
            'appversion' => '1.6.009',
            'platform' => 'android',
            'pushstate' => 'enabled'
          };
```
