### PR TITLE
Scripted installation fails - no-interactive does not apply to install commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -184,7 +184,7 @@ verify_config() {
 
     fi
     echo
-    if [[ ${INTERACTIVE} == 'no']]
+    if [[ ${INTERACTIVE} == 'no' ]]
     then
         echo "Non interactive mode, installer will answer yes to all questions."
         if [[ ${INSTALLER} == 'apt-get' ]]

--- a/install.sh
+++ b/install.sh
@@ -184,6 +184,16 @@ verify_config() {
 
     fi
     echo
+    if [[ ${INTERACTIVE} == 'no']]
+    then
+        echo "Non interactive mode, installer will answer yes to all questions."
+        if [[ ${INSTALLER} == 'apt-get' ]]
+        then
+            INSTALLER="${INSTALLER} -yq"
+        else
+            INSTALLER="${INSTALLER} -y"
+        fi
+    fi
      [[ ${INTERACTIVE} == 'yes' ]] && read -p "If any of this looks wrong, please hit Ctrl+C and edit the variables in this script..."
 
 }


### PR DESCRIPTION
I'm using a completely scripted installation to bring up a docker container, but it fails when using install.sh.
But install.sh already supports "no-interactive" - which is great and would fullfill all the needs.
While running it, it does not take into account, that apt-get or yum (the two supported installer) might ask stuff. 

I changed it, so in case "no-interactive" is set, I add "-yq" for apt-get or "-y" for yum to the INSTALLER variable and this does the trick in my setup.