### PR TITLE
Added pyzm_overrides warning in case ZoneMinder connects to database using UNIX socket

### DIFF
--- a/hook/objectconfig.ini
+++ b/hook/objectconfig.ini
@@ -27,7 +27,17 @@ cpu_max_lock_wait=100
 tpu_max_lock_wait=100
 gpu_max_lock_wait=100
 
-
+# If your ZoneMinder setup is using UNIX socket to connect
+# a local database and in your zm.conf there is a line that 
+# looks like this one:
+# ZM_DB_HOST=localhost:/var/run/mysqld/mysqld.sock
+# Event Server won't play nice with it and zm_detect will fail.
+# Uncomment the following pyzm_overrides and properly populate 
+# dbhost entry with hostname:port to get zm_detect working.
+#
+#pyzm_overrides={'log_level_debug':5,'dbhost':'localhost:3386'}
+#
+# Use the following other configurations otherwise:
 #pyzm_overrides={'conf_path':'/etc/zm','log_level_debug':0}
 pyzm_overrides={'log_level_debug':5}
 

--- a/hook/objectconfig.ini
+++ b/hook/objectconfig.ini
@@ -35,7 +35,7 @@ gpu_max_lock_wait=100
 # Uncomment the following pyzm_overrides and properly populate 
 # dbhost entry with hostname:port to get zm_detect working.
 #
-#pyzm_overrides={'log_level_debug':5,'dbhost':'localhost:3386'}
+#pyzm_overrides={'log_level_debug':5,'dbhost':'localhost:3306'}
 #
 # Use the following other configurations otherwise:
 #pyzm_overrides={'conf_path':'/etc/zm','log_level_debug':0}


### PR DESCRIPTION
If ZoneMinder is configured to use UNIX socket to connect to a local database (connection string like  `ZM_DB_HOST=localhost:/var/run/mysqld/mysqld.sock`), `zm_detect.py` won't play nice with it and will throw an error similar to the following one:

```
$ /var/lib/zmeventnotification/bin/zm_detect.py --config /etc/zm/objectconfig.ini --eventid 1889346  --monitorid 11 --eventpath=/tmp --config /etc/zm/objectconfig.ini

Unrecoverable error:invalid literal for int() with base 10: '' Traceback:Traceback (most recent call last):
File "/var/lib/zmeventnotification/bin/zm_detect.py", line 550, in <module> main_handler()                                                                                                                                            File "/var/lib/zmeventnotification/bin/zm_detect.py", line 253, in main_handler                                                                               log.init(name='zmesdetect_' + 'm' + args.get('monitorid'), override=g.config['pyzm_overrides'])                                                           File "/usr/local/lib/python3.10/dist-packages/pyzm/ZMLog.py", line 227, in init
    engine = create_engine(cstr, pool_recycle=3600)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/__init__.py", line 525, in create_engine
   return strategy.create(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/strategies.py", line 54, in create
   u = url.make_url(name_or_url)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/url.py", line 229, in make_url
   return _parse_rfc1738_args(name_or_url)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/url.py", line 288, in _parse_rfc1738_args
   return URL(name, **components)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/url.py", line 71, in __init__
    self.port = int(port)
ValueError: invalid literal for int() with base 10: ''                                          
```

This PR adds the following warning in the `objectconfig.ini` configuration file to add a proper `pyzm_overrides` that will include the `dbhost` attribute with `hostname:port` format that will fix the issue, so `zm_detect.py` works in this scenario.

```
# If your ZoneMinder setup is using UNIX socket to connect
# a local database and in your zm.conf there is a line that 
# looks like this one:
# ZM_DB_HOST=localhost:/var/run/mysqld/mysqld.sock
# Event Server won't play nice with it and zm_detect will fail.
# Uncomment the following pyzm_overrides and properly populate 
# dbhost entry with hostname:port to get zm_detect working.
#
#pyzm_overrides={'log_level_debug':5,'dbhost':'localhost:3306'}
#
# Use the following other configurations otherwise:
#pyzm_overrides={'conf_path':'/etc/zm','log_level_debug':0}
pyzm_overrides={'log_level_debug':5}
```