### PR TITLE
Added numpy and imutils imports to remote_detect()

### DIFF
--- a/hook/zm_detect.py
+++ b/hook/zm_detect.py
@@ -29,6 +29,8 @@ def remote_detect(stream=None, options=None, api=None, args=None):
     import cv2
     import json
     import time
+    import numpy as np
+    import imutils
     
     bbox = []
     label = []


### PR DESCRIPTION
`remote_detect()` was missing `numpy` and `imutils` imports, throwing the following non-critical erros in the log:

```
ERR zm_detect.py:175 [Error during image grab: name 'np' is not defined]
```

```
ERR zm_detect.py:176 [Error during image grab: name 'imutils' is not defined]
```

This PR fixes the issues by adding the missing imports in `zm_detect.py`.
