### PR TITLE
pin old ES to older pyzms

### DIFF
--- a/hook/setup.py
+++ b/hook/setup.py
@@ -16,7 +16,7 @@ AUTHOR = 'Pliable Pixels'
 LICENSE = 'GPL'
 INSTALL_REQUIRES = [
     'numpy', 'requests', 'Shapely', 'imutils', 
-    'pyzm>=0.3.57', 'scikit-learn', 'future', 'imageio',
+    'pyzm<=0.3.68', 'scikit-learn', 'future', 'imageio',
     'imageio-ffmpeg','pygifsicle', 'Pillow', 'configupdater'
 ]
 


### PR DESCRIPTION
A new version has been developed to work with ES 7.0. We want to make sure the old ZMES continues to work with older packages